### PR TITLE
Fix build on linux w/clang7

### DIFF
--- a/cctools/.gitignore
+++ b/cctools/.gitignore
@@ -1,0 +1,7 @@
+**/Makefile
+aclocal.m4
+autom4te.cache/
+config.log
+config.status
+**/.dirstamp
+libtool

--- a/cctools/Makefile.in
+++ b/cctools/Makefile.in
@@ -90,10 +90,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = .
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
-	$(top_srcdir)/m4/llvm.m4 $(top_srcdir)/m4/ltoptions.m4 \
-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
-	$(top_srcdir)/m4/lt~obsolete.m4 $(top_srcdir)/configure.ac
+am__aclocal_m4_deps = $(top_srcdir)/m4/llvm.m4 \
+	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
 DIST_COMMON = $(srcdir)/Makefile.am $(top_srcdir)/configure \
@@ -161,9 +159,9 @@ ETAGS = etags
 CTAGS = ctags
 CSCOPE = cscope
 DIST_SUBDIRS = $(SUBDIRS)
-am__DIST_COMMON = $(srcdir)/Makefile.in AUTHORS COPYING ChangeLog \
-	INSTALL NEWS README compile config.guess config.sub install-sh \
-	ltmain.sh missing
+am__DIST_COMMON = $(srcdir)/Makefile.in AUTHORS COPYING ChangeLog NEWS \
+	README compile config.guess config.sub install-sh ltmain.sh \
+	missing
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 distdir = $(PACKAGE)-$(VERSION)
 top_distdir = $(distdir)
@@ -366,15 +364,15 @@ $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__confi
 	@for dep in $?; do \
 	  case '$(am__configure_deps)' in \
 	    *$$dep*) \
-	      echo ' cd $(srcdir) && $(AUTOMAKE) --gnu --ignore-deps'; \
-	      $(am__cd) $(srcdir) && $(AUTOMAKE) --gnu --ignore-deps \
+	      echo ' cd $(srcdir) && $(AUTOMAKE) --foreign --ignore-deps'; \
+	      $(am__cd) $(srcdir) && $(AUTOMAKE) --foreign --ignore-deps \
 		&& exit 0; \
 	      exit 1;; \
 	  esac; \
 	done; \
-	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu --ignore-deps Makefile'; \
+	echo ' cd $(top_srcdir) && $(AUTOMAKE) --foreign --ignore-deps Makefile'; \
 	$(am__cd) $(top_srcdir) && \
-	  $(AUTOMAKE) --gnu --ignore-deps Makefile
+	  $(AUTOMAKE) --foreign --ignore-deps Makefile
 Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	@case '$?' in \
 	  *config.status*) \

--- a/cctools/ar/Makefile.in
+++ b/cctools/ar/Makefile.in
@@ -92,10 +92,8 @@ target_triplet = @target@
 bin_PROGRAMS = ar$(EXEEXT)
 subdir = ar
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
-	$(top_srcdir)/m4/llvm.m4 $(top_srcdir)/m4/ltoptions.m4 \
-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
-	$(top_srcdir)/m4/lt~obsolete.m4 $(top_srcdir)/configure.ac
+am__aclocal_m4_deps = $(top_srcdir)/m4/llvm.m4 \
+	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
 DIST_COMMON = $(srcdir)/Makefile.am $(am__DIST_COMMON)
@@ -354,9 +352,9 @@ $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__confi
 	      exit 1;; \
 	  esac; \
 	done; \
-	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu --ignore-deps ar/Makefile'; \
+	echo ' cd $(top_srcdir) && $(AUTOMAKE) --foreign --ignore-deps ar/Makefile'; \
 	$(am__cd) $(top_srcdir) && \
-	  $(AUTOMAKE) --gnu --ignore-deps ar/Makefile
+	  $(AUTOMAKE) --foreign --ignore-deps ar/Makefile
 Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	@case '$?' in \
 	  *config.status*) \

--- a/cctools/as/Makefile.in
+++ b/cctools/as/Makefile.in
@@ -92,10 +92,8 @@ target_triplet = @target@
 bin_PROGRAMS = as$(EXEEXT)
 subdir = as
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
-	$(top_srcdir)/m4/llvm.m4 $(top_srcdir)/m4/ltoptions.m4 \
-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
-	$(top_srcdir)/m4/lt~obsolete.m4 $(top_srcdir)/configure.ac
+am__aclocal_m4_deps = $(top_srcdir)/m4/llvm.m4 \
+	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
 DIST_COMMON = $(srcdir)/Makefile.am $(am__DIST_COMMON)
@@ -383,9 +381,9 @@ $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__confi
 	      exit 1;; \
 	  esac; \
 	done; \
-	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu --ignore-deps as/Makefile'; \
+	echo ' cd $(top_srcdir) && $(AUTOMAKE) --foreign --ignore-deps as/Makefile'; \
 	$(am__cd) $(top_srcdir) && \
-	  $(AUTOMAKE) --gnu --ignore-deps as/Makefile
+	  $(AUTOMAKE) --foreign --ignore-deps as/Makefile
 Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	@case '$?' in \
 	  *config.status*) \

--- a/cctools/as/arm/Makefile.in
+++ b/cctools/as/arm/Makefile.in
@@ -92,10 +92,8 @@ target_triplet = @target@
 libexec_PROGRAMS = arm-as$(EXEEXT)
 subdir = as/arm
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
-	$(top_srcdir)/m4/llvm.m4 $(top_srcdir)/m4/ltoptions.m4 \
-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
-	$(top_srcdir)/m4/lt~obsolete.m4 $(top_srcdir)/configure.ac
+am__aclocal_m4_deps = $(top_srcdir)/m4/llvm.m4 \
+	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
 DIST_COMMON = $(srcdir)/Makefile.am $(am__DIST_COMMON)
@@ -357,9 +355,9 @@ $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__confi
 	      exit 1;; \
 	  esac; \
 	done; \
-	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu --ignore-deps as/arm/Makefile'; \
+	echo ' cd $(top_srcdir) && $(AUTOMAKE) --foreign --ignore-deps as/arm/Makefile'; \
 	$(am__cd) $(top_srcdir) && \
-	  $(AUTOMAKE) --gnu --ignore-deps as/arm/Makefile
+	  $(AUTOMAKE) --foreign --ignore-deps as/arm/Makefile
 Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	@case '$?' in \
 	  *config.status*) \

--- a/cctools/as/i386/Makefile.in
+++ b/cctools/as/i386/Makefile.in
@@ -92,10 +92,8 @@ target_triplet = @target@
 libexec_PROGRAMS = i386-as$(EXEEXT)
 subdir = as/i386
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
-	$(top_srcdir)/m4/llvm.m4 $(top_srcdir)/m4/ltoptions.m4 \
-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
-	$(top_srcdir)/m4/lt~obsolete.m4 $(top_srcdir)/configure.ac
+am__aclocal_m4_deps = $(top_srcdir)/m4/llvm.m4 \
+	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
 DIST_COMMON = $(srcdir)/Makefile.am $(am__DIST_COMMON)
@@ -358,9 +356,9 @@ $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__confi
 	      exit 1;; \
 	  esac; \
 	done; \
-	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu --ignore-deps as/i386/Makefile'; \
+	echo ' cd $(top_srcdir) && $(AUTOMAKE) --foreign --ignore-deps as/i386/Makefile'; \
 	$(am__cd) $(top_srcdir) && \
-	  $(AUTOMAKE) --gnu --ignore-deps as/i386/Makefile
+	  $(AUTOMAKE) --foreign --ignore-deps as/i386/Makefile
 Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	@case '$?' in \
 	  *config.status*) \

--- a/cctools/as/ppc/Makefile.in
+++ b/cctools/as/ppc/Makefile.in
@@ -92,10 +92,8 @@ target_triplet = @target@
 libexec_PROGRAMS = ppc-as$(EXEEXT)
 subdir = as/ppc
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
-	$(top_srcdir)/m4/llvm.m4 $(top_srcdir)/m4/ltoptions.m4 \
-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
-	$(top_srcdir)/m4/lt~obsolete.m4 $(top_srcdir)/configure.ac
+am__aclocal_m4_deps = $(top_srcdir)/m4/llvm.m4 \
+	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
 DIST_COMMON = $(srcdir)/Makefile.am $(am__DIST_COMMON)
@@ -357,9 +355,9 @@ $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__confi
 	      exit 1;; \
 	  esac; \
 	done; \
-	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu --ignore-deps as/ppc/Makefile'; \
+	echo ' cd $(top_srcdir) && $(AUTOMAKE) --foreign --ignore-deps as/ppc/Makefile'; \
 	$(am__cd) $(top_srcdir) && \
-	  $(AUTOMAKE) --gnu --ignore-deps as/ppc/Makefile
+	  $(AUTOMAKE) --foreign --ignore-deps as/ppc/Makefile
 Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	@case '$?' in \
 	  *config.status*) \

--- a/cctools/as/ppc64/Makefile.in
+++ b/cctools/as/ppc64/Makefile.in
@@ -92,10 +92,8 @@ target_triplet = @target@
 libexec_PROGRAMS = ppc64-as$(EXEEXT)
 subdir = as/ppc64
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
-	$(top_srcdir)/m4/llvm.m4 $(top_srcdir)/m4/ltoptions.m4 \
-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
-	$(top_srcdir)/m4/lt~obsolete.m4 $(top_srcdir)/configure.ac
+am__aclocal_m4_deps = $(top_srcdir)/m4/llvm.m4 \
+	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
 DIST_COMMON = $(srcdir)/Makefile.am $(am__DIST_COMMON)
@@ -359,9 +357,9 @@ $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__confi
 	      exit 1;; \
 	  esac; \
 	done; \
-	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu --ignore-deps as/ppc64/Makefile'; \
+	echo ' cd $(top_srcdir) && $(AUTOMAKE) --foreign --ignore-deps as/ppc64/Makefile'; \
 	$(am__cd) $(top_srcdir) && \
-	  $(AUTOMAKE) --gnu --ignore-deps as/ppc64/Makefile
+	  $(AUTOMAKE) --foreign --ignore-deps as/ppc64/Makefile
 Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	@case '$?' in \
 	  *config.status*) \

--- a/cctools/as/x86_64/Makefile.in
+++ b/cctools/as/x86_64/Makefile.in
@@ -92,10 +92,8 @@ target_triplet = @target@
 libexec_PROGRAMS = x86_64-as$(EXEEXT)
 subdir = as/x86_64
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
-	$(top_srcdir)/m4/llvm.m4 $(top_srcdir)/m4/ltoptions.m4 \
-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
-	$(top_srcdir)/m4/lt~obsolete.m4 $(top_srcdir)/configure.ac
+am__aclocal_m4_deps = $(top_srcdir)/m4/llvm.m4 \
+	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
 DIST_COMMON = $(srcdir)/Makefile.am $(am__DIST_COMMON)
@@ -361,9 +359,9 @@ $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__confi
 	      exit 1;; \
 	  esac; \
 	done; \
-	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu --ignore-deps as/x86_64/Makefile'; \
+	echo ' cd $(top_srcdir) && $(AUTOMAKE) --foreign --ignore-deps as/x86_64/Makefile'; \
 	$(am__cd) $(top_srcdir) && \
-	  $(AUTOMAKE) --gnu --ignore-deps as/x86_64/Makefile
+	  $(AUTOMAKE) --foreign --ignore-deps as/x86_64/Makefile
 Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	@case '$?' in \
 	  *config.status*) \

--- a/cctools/configure
+++ b/cctools/configure
@@ -2601,7 +2601,7 @@ if test "x$OBJCFLAGS" = "x"; then
   OBJCFLAGS="-O3"
 fi
 
-CXXFLAGS="$CXXFLAGS -std=c++0x"
+CXXFLAGS="$CXXFLAGS -std=c++11"
 
 if test "x$build" = "x$host"; then
   CFLAGS="$CFLAGS -isystem /usr/local/include -isystem /usr/pkg/include"
@@ -8548,10 +8548,6 @@ _lt_linker_boilerplate=`cat conftest.err`
 $RM -r conftest*
 
 
-## CAVEAT EMPTOR:
-## There is no encapsulation within the following macros, do not change
-## the running order or otherwise move them around unless you know exactly
-## what you are doing...
 if test -n "$compiler"; then
 
 lt_prog_compiler_no_builtin_flag=
@@ -11987,7 +11983,7 @@ $as_echo_n "checking whether a program can dlopen itself... " >&6; }
 if ${lt_cv_dlopen_self+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-	  if test yes = "$cross_compiling"; then :
+  	  if test yes = "$cross_compiling"; then :
   lt_cv_dlopen_self=cross
 else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
@@ -12093,7 +12089,7 @@ $as_echo_n "checking whether a statically linked program can dlopen itself... " 
 if ${lt_cv_dlopen_self_static+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-	  if test yes = "$cross_compiling"; then :
+  	  if test yes = "$cross_compiling"; then :
   lt_cv_dlopen_self_static=cross
 else
   lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
@@ -20328,3 +20324,4 @@ if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: unrecognized options: $ac_unrecognized_opts" >&5
 $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
 fi
+

--- a/cctools/configure.ac
+++ b/cctools/configure.ac
@@ -23,7 +23,7 @@ if test "x$OBJCFLAGS" = "x"; then
   OBJCFLAGS="-O3"
 fi
 
-CXXFLAGS="$CXXFLAGS -std=c++0x"
+CXXFLAGS="$CXXFLAGS -std=c++11"
 
 if test "x$build" = "x$host"; then
   CFLAGS="$CFLAGS -isystem /usr/local/include -isystem /usr/pkg/include"

--- a/cctools/ld64/Makefile.am
+++ b/cctools/ld64/Makefile.am
@@ -1,2 +1,2 @@
-SUBDIRS = src doc/man
+SUBDIRS = src #doc/man
 ACLOCAL_AMFLAGS = -I m4

--- a/cctools/ld64/Makefile.in
+++ b/cctools/ld64/Makefile.in
@@ -90,10 +90,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = ld64
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
-	$(top_srcdir)/m4/llvm.m4 $(top_srcdir)/m4/ltoptions.m4 \
-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
-	$(top_srcdir)/m4/lt~obsolete.m4 $(top_srcdir)/configure.ac
+am__aclocal_m4_deps = $(top_srcdir)/m4/llvm.m4 \
+	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
 DIST_COMMON = $(srcdir)/Makefile.am $(am__DIST_COMMON)
@@ -107,11 +105,11 @@ am__v_P_1 = :
 AM_V_GEN = $(am__v_GEN_@AM_V@)
 am__v_GEN_ = $(am__v_GEN_@AM_DEFAULT_V@)
 am__v_GEN_0 = @echo "  GEN     " $@;
-am__v_GEN_1 =
+am__v_GEN_1 = 
 AM_V_at = $(am__v_at_@AM_V@)
 am__v_at_ = $(am__v_at_@AM_DEFAULT_V@)
 am__v_at_0 = @
-am__v_at_1 =
+am__v_at_1 = 
 depcomp =
 am__maybe_remake_depfiles =
 SOURCES =
@@ -331,7 +329,7 @@ target_vendor = @target_vendor@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
-SUBDIRS = src
+SUBDIRS = src #doc/man
 ACLOCAL_AMFLAGS = -I m4
 all: all-recursive
 
@@ -345,9 +343,9 @@ $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__confi
 	      exit 1;; \
 	  esac; \
 	done; \
-	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu --ignore-deps ld64/Makefile'; \
+	echo ' cd $(top_srcdir) && $(AUTOMAKE) --foreign --ignore-deps ld64/Makefile'; \
 	$(am__cd) $(top_srcdir) && \
-	  $(AUTOMAKE) --gnu --ignore-deps ld64/Makefile
+	  $(AUTOMAKE) --foreign --ignore-deps ld64/Makefile
 Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	@case '$?' in \
 	  *config.status*) \

--- a/cctools/ld64/src/3rd/BlocksRuntime/Makefile.in
+++ b/cctools/ld64/src/3rd/BlocksRuntime/Makefile.in
@@ -92,10 +92,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = ld64/src/3rd/BlocksRuntime
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
-	$(top_srcdir)/m4/llvm.m4 $(top_srcdir)/m4/ltoptions.m4 \
-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
-	$(top_srcdir)/m4/lt~obsolete.m4 $(top_srcdir)/configure.ac
+am__aclocal_m4_deps = $(top_srcdir)/m4/llvm.m4 \
+	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
 DIST_COMMON = $(srcdir)/Makefile.am $(noinst_HEADERS) \
@@ -343,9 +341,9 @@ $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__confi
 	      exit 1;; \
 	  esac; \
 	done; \
-	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu --ignore-deps ld64/src/3rd/BlocksRuntime/Makefile'; \
+	echo ' cd $(top_srcdir) && $(AUTOMAKE) --foreign --ignore-deps ld64/src/3rd/BlocksRuntime/Makefile'; \
 	$(am__cd) $(top_srcdir) && \
-	  $(AUTOMAKE) --gnu --ignore-deps ld64/src/3rd/BlocksRuntime/Makefile
+	  $(AUTOMAKE) --foreign --ignore-deps ld64/src/3rd/BlocksRuntime/Makefile
 Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	@case '$?' in \
 	  *config.status*) \

--- a/cctools/ld64/src/3rd/Makefile.in
+++ b/cctools/ld64/src/3rd/Makefile.in
@@ -92,10 +92,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = ld64/src/3rd
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
-	$(top_srcdir)/m4/llvm.m4 $(top_srcdir)/m4/ltoptions.m4 \
-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
-	$(top_srcdir)/m4/lt~obsolete.m4 $(top_srcdir)/configure.ac
+am__aclocal_m4_deps = $(top_srcdir)/m4/llvm.m4 \
+	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
 DIST_COMMON = $(srcdir)/Makefile.am $(noinst_HEADERS) \
@@ -393,9 +391,9 @@ $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__confi
 	      exit 1;; \
 	  esac; \
 	done; \
-	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu --ignore-deps ld64/src/3rd/Makefile'; \
+	echo ' cd $(top_srcdir) && $(AUTOMAKE) --foreign --ignore-deps ld64/src/3rd/Makefile'; \
 	$(am__cd) $(top_srcdir) && \
-	  $(AUTOMAKE) --gnu --ignore-deps ld64/src/3rd/Makefile
+	  $(AUTOMAKE) --foreign --ignore-deps ld64/src/3rd/Makefile
 Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	@case '$?' in \
 	  *config.status*) \

--- a/cctools/ld64/src/Makefile.in
+++ b/cctools/ld64/src/Makefile.in
@@ -90,10 +90,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = ld64/src
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
-	$(top_srcdir)/m4/llvm.m4 $(top_srcdir)/m4/ltoptions.m4 \
-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
-	$(top_srcdir)/m4/lt~obsolete.m4 $(top_srcdir)/configure.ac
+am__aclocal_m4_deps = $(top_srcdir)/m4/llvm.m4 \
+	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
 DIST_COMMON = $(srcdir)/Makefile.am $(am__DIST_COMMON)
@@ -344,9 +342,9 @@ $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__confi
 	      exit 1;; \
 	  esac; \
 	done; \
-	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu --ignore-deps ld64/src/Makefile'; \
+	echo ' cd $(top_srcdir) && $(AUTOMAKE) --foreign --ignore-deps ld64/src/Makefile'; \
 	$(am__cd) $(top_srcdir) && \
-	  $(AUTOMAKE) --gnu --ignore-deps ld64/src/Makefile
+	  $(AUTOMAKE) --foreign --ignore-deps ld64/src/Makefile
 Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	@case '$?' in \
 	  *config.status*) \

--- a/cctools/ld64/src/ld/HeaderAndLoadCommands.hpp
+++ b/cctools/ld64/src/ld/HeaderAndLoadCommands.hpp
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <limits.h>
 #include <unistd.h>
+#include <mutex>
 #include <mach-o/loader.h>
 
 #include <vector>

--- a/cctools/ld64/src/ld/Makefile.in
+++ b/cctools/ld64/src/ld/Makefile.in
@@ -92,10 +92,8 @@ target_triplet = @target@
 bin_PROGRAMS = ld$(EXEEXT)
 subdir = ld64/src/ld
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
-	$(top_srcdir)/m4/llvm.m4 $(top_srcdir)/m4/ltoptions.m4 \
-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
-	$(top_srcdir)/m4/lt~obsolete.m4 $(top_srcdir)/configure.ac
+am__aclocal_m4_deps = $(top_srcdir)/m4/llvm.m4 \
+	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
 DIST_COMMON = $(srcdir)/Makefile.am $(am__DIST_COMMON)
@@ -465,9 +463,9 @@ $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__confi
 	      exit 1;; \
 	  esac; \
 	done; \
-	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu --ignore-deps ld64/src/ld/Makefile'; \
+	echo ' cd $(top_srcdir) && $(AUTOMAKE) --foreign --ignore-deps ld64/src/ld/Makefile'; \
 	$(am__cd) $(top_srcdir) && \
-	  $(AUTOMAKE) --gnu --ignore-deps ld64/src/ld/Makefile
+	  $(AUTOMAKE) --foreign --ignore-deps ld64/src/ld/Makefile
 Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	@case '$?' in \
 	  *config.status*) \

--- a/cctools/ld64/src/ld/Options.cpp
+++ b/cctools/ld64/src/ld/Options.cpp
@@ -1260,7 +1260,7 @@ std::vector<const char*> Options::exportsData() const
 std::vector<const char*> Options::SetWithWildcards::data() const
 {
 	std::vector<const char*> data;
-	for (NameSet::iterator it=regularBegin(); it != regularEnd(); ++it) {
+	for (NameSet::const_iterator it=regularBegin(); it != regularEnd(); ++it) {
 		data.push_back(*it);
 	}
 	for (std::vector<const char*>::const_iterator it=fWildCard.begin(); it != fWildCard.end(); ++it) {
@@ -4695,9 +4695,11 @@ void Options::reconfigureDefaults()
 		case Options::kDynamicBundle:
 			break;
 		case Options::kDyld:
+#ifdef CPU_SUBTYPE_ARM64_E
 			// arm64e has support for compressed LINKEDIT.
 			if ( (fArchitecture == CPU_TYPE_ARM64) && (fSubArchitecture == CPU_SUBTYPE_ARM64_E) )
 				break;
+#endif
 		case Options::kPreload:
 		case Options::kStaticExecutable:
 		case Options::kObjectFile:
@@ -5525,7 +5527,7 @@ void Options::checkIllegalOptionCombinations()
 
 	// make sure all required exported symbols exist
 	std::vector<const char*> impliedExports;
-	for (NameSet::iterator it=fExportSymbols.regularBegin(); it != fExportSymbols.regularEnd(); ++it) {
+	for (NameSet::const_iterator it=fExportSymbols.regularBegin(); it != fExportSymbols.regularEnd(); ++it) {
 		const char* name = *it;
 		const int len = strlen(name);
 		if ( (strcmp(&name[len-3], ".eh") == 0) || (strncmp(name, ".objc_category_name_", 20) == 0) ) {
@@ -5557,7 +5559,7 @@ void Options::checkIllegalOptionCombinations()
 	}
 
 	// make sure all required re-exported symbols exist
-	for (NameSet::iterator it=fReExportSymbols.regularBegin(); it != fReExportSymbols.regularEnd(); ++it) {
+	for (NameSet::const_iterator it=fReExportSymbols.regularBegin(); it != fReExportSymbols.regularEnd(); ++it) {
 		fInitialUndefines.push_back(*it);
 	}
 
@@ -5769,9 +5771,12 @@ void Options::checkIllegalOptionCombinations()
 	if (platforms().count() > 2) {
 		throw "Illegal platform count.  Only 2 platforms at a maximum can be specified";
 	}
-
+#ifdef CPU_TYPE_X86
 	// Convert from -ios_version_min to -ios_simulator_version_min for now until clang has been updated
 	if (architecture() == CPU_TYPE_X86_64 || architecture() == CPU_TYPE_X86) {
+#else
+	if (architecture() == CPU_TYPE_X86_64) {
+#endif
 		if (platforms().contains(ld::kPlatform_iOS)) {
 			uint32_t version = platforms().minOS(ld::kPlatform_iOS);
 			fPlatforms.erase(ld::kPlatform_iOS);

--- a/cctools/ld64/src/ld/Options.h
+++ b/cctools/ld64/src/ld/Options.h
@@ -558,8 +558,8 @@ private:
 		bool					containsNonWildcard(const char*) const;
 		bool					empty() const			{ return fRegular.empty() && fWildCard.empty(); }
 		bool					hasWildCards() const	{ return !fWildCard.empty(); }
-		NameSet::iterator		regularBegin() const	{ return fRegular.begin(); }
-		NameSet::iterator		regularEnd() const		{ return fRegular.end(); }
+		NameSet::const_iterator		regularBegin() const	{ return fRegular.begin(); }
+		NameSet::const_iterator		regularEnd() const		{ return fRegular.end(); }
 		void					remove(const NameSet&);
 		std::vector<const char*>		data() const;
 	private:
@@ -870,7 +870,7 @@ private:
 	uint8_t								fMaxDefaultCommonAlign;
 	UnalignedPointerTreatment			fUnalignedPointerTreatment;
 	mutable std::vector<DependencyEntry> fDependencies;
-#ifdef TAPI_SUPPOTR
+#ifdef TAPI_SUPPORT
 	mutable std::vector<Options::TAPIInterface> fTAPIFiles;
 #endif
 

--- a/cctools/ld64/src/ld/OutputFile.cpp
+++ b/cctools/ld64/src/ld/OutputFile.cpp
@@ -3078,13 +3078,12 @@ void OutputFile::computeContentUUID(ld::Internal& state, uint8_t* wholeBuffer)
 	}
 }
 
-static int sDescriptorOfPathToRemove = -1;
+static char sPathToRemove[MAXPATHLEN];
 static void removePathAndExit(int sig)
 {
-	if ( sDescriptorOfPathToRemove != -1 ) {
-		char path[MAXPATHLEN];
-		if ( ::fcntl(sDescriptorOfPathToRemove, F_GETPATH, path) == 0 )
-			::unlink(path);
+	if ( sPathToRemove[0] ) {
+		::unlink(sPathToRemove);
+		sPathToRemove[0] = 0;
 	}
 	fprintf(stderr, "ld: interrupted\n");
 	exit(1);
@@ -3166,10 +3165,11 @@ void OutputFile::writeOutputFile(ld::Internal& state)
 		strcpy(tmpOutput, _options.outputFilePath());
 		// If the path is too long to add a suffix for a temporary name then
 		// just fall back to using the output path. 
-		if (strlen(tmpOutput)+strlen(filenameTemplate) < PATH_MAX) {
+		size_t outlen = strlen(tmpOutput) + strlen(filenameTemplate);
+		if (outlen < PATH_MAX) {
 			strcat(tmpOutput, filenameTemplate);
 			fd = mkstemp(tmpOutput);
-			sDescriptorOfPathToRemove = fd;
+			strcpy(sPathToRemove, tmpOutput);
 		} 
 		else {
 			fd = open(tmpOutput, O_RDWR|O_CREAT, permissions);
@@ -3232,7 +3232,7 @@ void OutputFile::writeOutputFile(ld::Internal& state)
 		if ( ::write(fd, wholeBuffer, _fileSize) == -1 ) {
 			throwf("can't write to output file: %s, errno=%d", _options.outputFilePath(), errno);
 		}
-		sDescriptorOfPathToRemove = -1;
+		sPathToRemove[0] = 0;
 		::close(fd);
 		// <rdar://problem/13118223> NFS: iOS incremental builds in Xcode 4.6 fail with codesign error
 		// NFS seems to pad the end of the file sometimes.  Calling trunc seems to correct it...

--- a/cctools/ld64/src/ld/Snapshot.cpp
+++ b/cctools/ld64/src/ld/Snapshot.cpp
@@ -228,6 +228,19 @@ void Snapshot::copyFileToSnapshot(const char *sourcePath, const char *subdir, ch
     memmove(path, relPath, 1+strlen(relPath));
 }
 
+int mkpath(char* file_path, mode_t mode) {
+  assert(file_path && *file_path);
+  char* p;
+  for (p=strchr(file_path+1, '/'); p; p=strchr(p+1, '/')) {
+    *p='\0';
+    if (mkdir(file_path, mode)==-1) {
+      if (errno!=EEXIST) { *p='/'; return -1; }
+    }
+    *p='/';
+  }
+  return 0;
+}
+
 // Create the snapshot root directory.
 void Snapshot::createSnapshot()
 {
@@ -245,7 +258,7 @@ void Snapshot::createSnapshot()
         buildUniquePath(buf, NULL, fSnapshotName);
         fRootDir = strdup(buf);
 
-        int mkpatherr = mkpath_np(fRootDir, (S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH|S_IXUSR|S_IXGRP|S_IXOTH));
+        int mkpatherr = mkpath(buf, (S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH|S_IXUSR|S_IXGRP|S_IXOTH));
         if ((mkpatherr!=0) && !(fRecordKext && (mkpatherr==EEXIST))) {
             warning("unable to create link snapshot directory: %s", fRootDir);
             fRootDir = NULL;

--- a/cctools/ld64/src/ld/code-sign-blobs/blob.cpp
+++ b/cctools/ld64/src/ld/code-sign-blobs/blob.cpp
@@ -22,6 +22,7 @@
  */
 
 #include <unistd.h>
+#include <string.h>
 
 //
 // blob - generic extensible binary blob frame

--- a/cctools/ld64/src/ld/code-sign-blobs/endian.h
+++ b/cctools/ld64/src/ld/code-sign-blobs/endian.h
@@ -30,6 +30,7 @@
 
 #include <machine/endian.h>
 #include <libkern/OSByteOrder.h>
+#include <arpa/inet.h>
 //#include <security_utilities/utilities.h>
 #include "memutils.h"
 

--- a/cctools/ld64/src/ld/ld.cpp
+++ b/cctools/ld64/src/ld/ld.cpp
@@ -23,7 +23,7 @@
  */
  
 // start temp HACK for cross builds
-extern "C" double log2 ( double );
+//extern "C" double log2 ( double );
 //#define __MATH__
 // end temp HACK for cross builds
 

--- a/cctools/ld64/src/ld/parsers/Makefile.in
+++ b/cctools/ld64/src/ld/parsers/Makefile.in
@@ -92,10 +92,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = ld64/src/ld/parsers
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
-	$(top_srcdir)/m4/llvm.m4 $(top_srcdir)/m4/ltoptions.m4 \
-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
-	$(top_srcdir)/m4/lt~obsolete.m4 $(top_srcdir)/configure.ac
+am__aclocal_m4_deps = $(top_srcdir)/m4/llvm.m4 \
+	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
 DIST_COMMON = $(srcdir)/Makefile.am $(noinst_HEADERS) \
@@ -375,9 +373,9 @@ $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__confi
 	      exit 1;; \
 	  esac; \
 	done; \
-	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu --ignore-deps ld64/src/ld/parsers/Makefile'; \
+	echo ' cd $(top_srcdir) && $(AUTOMAKE) --foreign --ignore-deps ld64/src/ld/parsers/Makefile'; \
 	$(am__cd) $(top_srcdir) && \
-	  $(AUTOMAKE) --gnu --ignore-deps ld64/src/ld/parsers/Makefile
+	  $(AUTOMAKE) --foreign --ignore-deps ld64/src/ld/parsers/Makefile
 Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	@case '$?' in \
 	  *config.status*) \

--- a/cctools/ld64/src/ld/parsers/macho_relocatable_file.cpp
+++ b/cctools/ld64/src/ld/parsers/macho_relocatable_file.cpp
@@ -1229,9 +1229,13 @@ private:
 	void											makeSortedSymbolsArray(uint32_t symArray[], const uint32_t sectionArray[]);
 	void											makeSortedSectionsArray(uint32_t array[]);
 	static int										pointerSorter(const void* l, const void* r);
-	static int										symbolIndexSorter(void* extra, const void* l, const void* r);
-	static int										sectionIndexSorter(void* extra, const void* l, const void* r);
-
+    #ifdef _GNU_SOURCE
+	static int symbolIndexSorter(const void* l, const void* r, void* extra);
+	static int sectionIndexSorter(const void* l, const void* r, void* extra);
+	#else
+	static int symbolIndexSorter(void* extra, const void* l, const void* r);
+	static int sectionIndexSorter(void* extra, const void* l, const void* r);
+	#endif
 	void											parseDebugInfo();
 	void											parseStabs();
 	void											addAstFiles();
@@ -2367,7 +2371,11 @@ void Parser<A>::appendAliasAtoms(uint8_t* p)
 
 
 template <typename A>
+#ifdef _GNU_SOURCE
+int Parser<A>::sectionIndexSorter(const void* l, const void* r, void* extra)
+#else
 int Parser<A>::sectionIndexSorter(void* extra, const void* l, const void* r)
+#endif
 {
 	Parser<A>* parser = (Parser<A>*)extra;
 	const uint32_t* left = (uint32_t*)l;
@@ -2410,7 +2418,11 @@ void Parser<A>::makeSortedSectionsArray(uint32_t array[])
 	// sort by symbol table address
 	for (uint32_t i=0; i < _machOSectionsCount; ++i)
 		array[i] = i;
+#ifdef _GNU_SOURCE
+	::qsort_r(array, _machOSectionsCount, sizeof(uint32_t), &sectionIndexSorter, this);
+#else
 	::qsort_r(array, _machOSectionsCount, sizeof(uint32_t), this, &sectionIndexSorter);
+#endif
 
 	if ( log ) {
 		fprintf(stderr, "sorted sections:\n");
@@ -2422,7 +2434,11 @@ void Parser<A>::makeSortedSectionsArray(uint32_t array[])
 
 
 template <typename A>
+#ifdef _GNU_SOURCE
+int Parser<A>::symbolIndexSorter(const void* l, const void* r, void* extra)
+#else
 int Parser<A>::symbolIndexSorter(void* extra, const void* l, const void* r)
+#endif
 {
 	ParserAndSectionsArray* extraInfo = (ParserAndSectionsArray*)extra;
 	Parser<A>* parser = extraInfo->parser;
@@ -2503,7 +2519,11 @@ void Parser<A>::makeSortedSymbolsArray(uint32_t array[], const uint32_t sectionA
 	
 	// sort by symbol table address
 	ParserAndSectionsArray extra = { this, sectionArray };
+#ifdef _GNU_SOURCE
+	::qsort_r(array, _symbolsInSections, sizeof(uint32_t), &symbolIndexSorter, &extra);
+#else
 	::qsort_r(array, _symbolsInSections, sizeof(uint32_t), &extra, &symbolIndexSorter);
+#endif
 
 	
 	// look for two symbols at same address

--- a/cctools/ld64/src/ld/passes/Makefile.am
+++ b/cctools/ld64/src/ld/passes/Makefile.am
@@ -40,5 +40,5 @@ libPasses_la_SOURCES =  \
 	tlvp.cpp \
 	stubs/stubs.cpp \
 	bitcode_bundle.cpp \
+  thread_starts.cpp \
 	code_dedup.cpp
-

--- a/cctools/ld64/src/ld/passes/Makefile.in
+++ b/cctools/ld64/src/ld/passes/Makefile.in
@@ -92,10 +92,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = ld64/src/ld/passes
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
-	$(top_srcdir)/m4/llvm.m4 $(top_srcdir)/m4/ltoptions.m4 \
-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
-	$(top_srcdir)/m4/lt~obsolete.m4 $(top_srcdir)/configure.ac
+am__aclocal_m4_deps = $(top_srcdir)/m4/llvm.m4 \
+	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
 DIST_COMMON = $(srcdir)/Makefile.am $(noinst_HEADERS) \
@@ -112,7 +110,7 @@ am_libPasses_la_OBJECTS = libPasses_la-branch_island.lo \
 	libPasses_la-got.lo libPasses_la-huge.lo libPasses_la-objc.lo \
 	libPasses_la-order.lo libPasses_la-tlvp.lo \
 	stubs/libPasses_la-stubs.lo libPasses_la-bitcode_bundle.lo \
-	libPasses_la-code_dedup.lo
+	libPasses_la-thread_starts.lo libPasses_la-code_dedup.lo
 libPasses_la_OBJECTS = $(am_libPasses_la_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
@@ -371,6 +369,7 @@ libPasses_la_SOURCES = \
 	tlvp.cpp \
 	stubs/stubs.cpp \
 	bitcode_bundle.cpp \
+  thread_starts.cpp \
 	code_dedup.cpp
 
 all: all-am
@@ -386,9 +385,9 @@ $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__confi
 	      exit 1;; \
 	  esac; \
 	done; \
-	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu --ignore-deps ld64/src/ld/passes/Makefile'; \
+	echo ' cd $(top_srcdir) && $(AUTOMAKE) --foreign --ignore-deps ld64/src/ld/passes/Makefile'; \
 	$(am__cd) $(top_srcdir) && \
-	  $(AUTOMAKE) --gnu --ignore-deps ld64/src/ld/passes/Makefile
+	  $(AUTOMAKE) --foreign --ignore-deps ld64/src/ld/passes/Makefile
 Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	@case '$?' in \
 	  *config.status*) \
@@ -477,6 +476,9 @@ stubs/libPasses_la-stubs.lo: stubs/stubs.cpp
 
 libPasses_la-bitcode_bundle.lo: bitcode_bundle.cpp
 	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libPasses_la_CXXFLAGS) $(CXXFLAGS) -c -o libPasses_la-bitcode_bundle.lo `test -f 'bitcode_bundle.cpp' || echo '$(srcdir)/'`bitcode_bundle.cpp
+
+libPasses_la-thread_starts.lo: thread_starts.cpp
+	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libPasses_la_CXXFLAGS) $(CXXFLAGS) -c -o libPasses_la-thread_starts.lo `test -f 'thread_starts.cpp' || echo '$(srcdir)/'`thread_starts.cpp
 
 libPasses_la-code_dedup.lo: code_dedup.cpp
 	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libPasses_la_CXXFLAGS) $(CXXFLAGS) -c -o libPasses_la-code_dedup.lo `test -f 'code_dedup.cpp' || echo '$(srcdir)/'`code_dedup.cpp

--- a/cctools/ld64/src/other/Makefile.am
+++ b/cctools/ld64/src/other/Makefile.am
@@ -1,6 +1,5 @@
 bin_PROGRAMS =  \
 	dyldinfo \
-	ObjectDump \
 	unwinddump \
 	machocheck
 
@@ -37,13 +36,6 @@ unwinddump_SOURCES = unwinddump.cpp
 
 machocheck_SOURCES = machochecker.cpp
 machocheck_LDADD = $(top_builddir)/ld64/src/3rd/libhelper.la
-
-ObjectDump_SOURCES = \
-	ObjectDump.cpp \
-	$(top_srcdir)/ld64/src/ld/debugline.c 
-ObjectDump_LDADD =  \
-	$(top_builddir)/ld64/src/ld/parsers/libParsers.la \
-	$(LTO_LIB)
 
 dyldinfo_SOURCES = dyldinfo.cpp
 dyldinfo_LDADD = $(top_builddir)/ld64/src/3rd/libhelper.la

--- a/cctools/ld64/src/other/Makefile.in
+++ b/cctools/ld64/src/other/Makefile.in
@@ -89,14 +89,12 @@ POST_UNINSTALL = :
 build_triplet = @build@
 host_triplet = @host@
 target_triplet = @target@
-bin_PROGRAMS = dyldinfo$(EXEEXT) ObjectDump$(EXEEXT) \
-	unwinddump$(EXEEXT) machocheck$(EXEEXT)
+bin_PROGRAMS = dyldinfo$(EXEEXT) unwinddump$(EXEEXT) \
+	machocheck$(EXEEXT)
 subdir = ld64/src/other
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
-	$(top_srcdir)/m4/llvm.m4 $(top_srcdir)/m4/ltoptions.m4 \
-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
-	$(top_srcdir)/m4/lt~obsolete.m4 $(top_srcdir)/configure.ac
+am__aclocal_m4_deps = $(top_srcdir)/m4/llvm.m4 \
+	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
 DIST_COMMON = $(srcdir)/Makefile.am $(am__DIST_COMMON)
@@ -105,21 +103,13 @@ CONFIG_CLEAN_FILES =
 CONFIG_CLEAN_VPATH_FILES =
 am__installdirs = "$(DESTDIR)$(bindir)"
 PROGRAMS = $(bin_PROGRAMS)
-am__dirstamp = $(am__leading_dot)dirstamp
-am_ObjectDump_OBJECTS = ObjectDump.$(OBJEXT) \
-	$(top_builddir)/ld64/src/ld/debugline.$(OBJEXT)
-ObjectDump_OBJECTS = $(am_ObjectDump_OBJECTS)
-am__DEPENDENCIES_1 =
-ObjectDump_DEPENDENCIES =  \
-	$(top_builddir)/ld64/src/ld/parsers/libParsers.la \
-	$(am__DEPENDENCIES_1)
+am_dyldinfo_OBJECTS = dyldinfo.$(OBJEXT)
+dyldinfo_OBJECTS = $(am_dyldinfo_OBJECTS)
+dyldinfo_DEPENDENCIES = $(top_builddir)/ld64/src/3rd/libhelper.la
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
 am__v_lt_0 = --silent
 am__v_lt_1 = 
-am_dyldinfo_OBJECTS = dyldinfo.$(OBJEXT)
-dyldinfo_OBJECTS = $(am_dyldinfo_OBJECTS)
-dyldinfo_DEPENDENCIES = $(top_builddir)/ld64/src/3rd/libhelper.la
 am_machocheck_OBJECTS = machochecker.$(OBJEXT)
 machocheck_OBJECTS = $(am_machocheck_OBJECTS)
 machocheck_DEPENDENCIES = $(top_builddir)/ld64/src/3rd/libhelper.la
@@ -141,24 +131,6 @@ am__v_at_1 =
 DEFAULT_INCLUDES = -I.@am__isrc@
 depcomp =
 am__maybe_remake_depfiles =
-COMPILE = $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
-	$(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
-LTCOMPILE = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
-	$(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) \
-	$(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) \
-	$(AM_CFLAGS) $(CFLAGS)
-AM_V_CC = $(am__v_CC_@AM_V@)
-am__v_CC_ = $(am__v_CC_@AM_DEFAULT_V@)
-am__v_CC_0 = @echo "  CC      " $@;
-am__v_CC_1 = 
-CCLD = $(CC)
-LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
-	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(AM_CFLAGS) $(CFLAGS) \
-	$(AM_LDFLAGS) $(LDFLAGS) -o $@
-AM_V_CCLD = $(am__v_CCLD_@AM_V@)
-am__v_CCLD_ = $(am__v_CCLD_@AM_DEFAULT_V@)
-am__v_CCLD_0 = @echo "  CCLD    " $@;
-am__v_CCLD_1 = 
 CXXCOMPILE = $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) \
 	$(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS)
 LTCXXCOMPILE = $(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) \
@@ -177,10 +149,10 @@ AM_V_CXXLD = $(am__v_CXXLD_@AM_V@)
 am__v_CXXLD_ = $(am__v_CXXLD_@AM_DEFAULT_V@)
 am__v_CXXLD_0 = @echo "  CXXLD   " $@;
 am__v_CXXLD_1 = 
-SOURCES = $(ObjectDump_SOURCES) $(dyldinfo_SOURCES) \
-	$(machocheck_SOURCES) $(unwinddump_SOURCES)
-DIST_SOURCES = $(ObjectDump_SOURCES) $(dyldinfo_SOURCES) \
-	$(machocheck_SOURCES) $(unwinddump_SOURCES)
+SOURCES = $(dyldinfo_SOURCES) $(machocheck_SOURCES) \
+	$(unwinddump_SOURCES)
+DIST_SOURCES = $(dyldinfo_SOURCES) $(machocheck_SOURCES) \
+	$(unwinddump_SOURCES)
 am__can_run_installinfo = \
   case $$AM_UPDATE_INFO_DIR in \
     n|no|NO) false;; \
@@ -386,20 +358,12 @@ AM_CFLAGS = \
 unwinddump_SOURCES = unwinddump.cpp
 machocheck_SOURCES = machochecker.cpp
 machocheck_LDADD = $(top_builddir)/ld64/src/3rd/libhelper.la
-ObjectDump_SOURCES = \
-	ObjectDump.cpp \
-	$(top_srcdir)/ld64/src/ld/debugline.c 
-
-ObjectDump_LDADD = \
-	$(top_builddir)/ld64/src/ld/parsers/libParsers.la \
-	$(LTO_LIB)
-
 dyldinfo_SOURCES = dyldinfo.cpp
 dyldinfo_LDADD = $(top_builddir)/ld64/src/3rd/libhelper.la
 all: all-am
 
 .SUFFIXES:
-.SUFFIXES: .c .cpp .lo .o .obj
+.SUFFIXES: .cpp .lo .o .obj
 $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__configure_deps)
 	@for dep in $?; do \
 	  case '$(am__configure_deps)' in \
@@ -409,9 +373,9 @@ $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__confi
 	      exit 1;; \
 	  esac; \
 	done; \
-	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu --ignore-deps ld64/src/other/Makefile'; \
+	echo ' cd $(top_srcdir) && $(AUTOMAKE) --foreign --ignore-deps ld64/src/other/Makefile'; \
 	$(am__cd) $(top_srcdir) && \
-	  $(AUTOMAKE) --gnu --ignore-deps ld64/src/other/Makefile
+	  $(AUTOMAKE) --foreign --ignore-deps ld64/src/other/Makefile
 Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	@case '$?' in \
 	  *config.status*) \
@@ -478,15 +442,6 @@ clean-binPROGRAMS:
 	list=`for p in $$list; do echo "$$p"; done | sed 's/$(EXEEXT)$$//'`; \
 	echo " rm -f" $$list; \
 	rm -f $$list
-$(top_builddir)/ld64/src/ld/$(am__dirstamp):
-	@$(MKDIR_P) $(top_builddir)/ld64/src/ld
-	@: > $(top_builddir)/ld64/src/ld/$(am__dirstamp)
-$(top_builddir)/ld64/src/ld/debugline.$(OBJEXT):  \
-	$(top_builddir)/ld64/src/ld/$(am__dirstamp)
-
-ObjectDump$(EXEEXT): $(ObjectDump_OBJECTS) $(ObjectDump_DEPENDENCIES) $(EXTRA_ObjectDump_DEPENDENCIES) 
-	@rm -f ObjectDump$(EXEEXT)
-	$(AM_V_CXXLD)$(CXXLINK) $(ObjectDump_OBJECTS) $(ObjectDump_LDADD) $(LIBS)
 
 dyldinfo$(EXEEXT): $(dyldinfo_OBJECTS) $(dyldinfo_DEPENDENCIES) $(EXTRA_dyldinfo_DEPENDENCIES) 
 	@rm -f dyldinfo$(EXEEXT)
@@ -502,19 +457,9 @@ unwinddump$(EXEEXT): $(unwinddump_OBJECTS) $(unwinddump_DEPENDENCIES) $(EXTRA_un
 
 mostlyclean-compile:
 	-rm -f *.$(OBJEXT)
-	-rm -f $(top_builddir)/ld64/src/ld/*.$(OBJEXT)
 
 distclean-compile:
 	-rm -f *.tab.c
-
-.c.o:
-	$(AM_V_CC)$(COMPILE) -c -o $@ $<
-
-.c.obj:
-	$(AM_V_CC)$(COMPILE) -c -o $@ `$(CYGPATH_W) '$<'`
-
-.c.lo:
-	$(AM_V_CC)$(LTCOMPILE) -c -o $@ $<
 
 .cpp.o:
 	$(AM_V_CXX)$(CXXCOMPILE) -c -o $@ $<
@@ -649,7 +594,6 @@ clean-generic:
 distclean-generic:
 	-test -z "$(CONFIG_CLEAN_FILES)" || rm -f $(CONFIG_CLEAN_FILES)
 	-test . = "$(srcdir)" || test -z "$(CONFIG_CLEAN_VPATH_FILES)" || rm -f $(CONFIG_CLEAN_VPATH_FILES)
-	-test -z "$(top_builddir)/ld64/src/ld/$(am__dirstamp)" || rm -f $(top_builddir)/ld64/src/ld/$(am__dirstamp)
 
 maintainer-clean-generic:
 	@echo "This command is intended for maintainers to use"

--- a/cctools/libobjc2/Makefile.in
+++ b/cctools/libobjc2/Makefile.in
@@ -91,10 +91,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = libobjc2
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
-	$(top_srcdir)/m4/llvm.m4 $(top_srcdir)/m4/ltoptions.m4 \
-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
-	$(top_srcdir)/m4/lt~obsolete.m4 $(top_srcdir)/configure.ac
+am__aclocal_m4_deps = $(top_srcdir)/m4/llvm.m4 \
+	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
 DIST_COMMON = $(srcdir)/Makefile.am $(am__DIST_COMMON)
@@ -413,9 +411,9 @@ $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__confi
 	      exit 1;; \
 	  esac; \
 	done; \
-	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu --ignore-deps libobjc2/Makefile'; \
+	echo ' cd $(top_srcdir) && $(AUTOMAKE) --foreign --ignore-deps libobjc2/Makefile'; \
 	$(am__cd) $(top_srcdir) && \
-	  $(AUTOMAKE) --gnu --ignore-deps libobjc2/Makefile
+	  $(AUTOMAKE) --foreign --ignore-deps libobjc2/Makefile
 Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	@case '$?' in \
 	  *config.status*) \

--- a/cctools/libstuff/Makefile.in
+++ b/cctools/libstuff/Makefile.in
@@ -91,10 +91,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = libstuff
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
-	$(top_srcdir)/m4/llvm.m4 $(top_srcdir)/m4/ltoptions.m4 \
-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
-	$(top_srcdir)/m4/lt~obsolete.m4 $(top_srcdir)/configure.ac
+am__aclocal_m4_deps = $(top_srcdir)/m4/llvm.m4 \
+	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
 DIST_COMMON = $(srcdir)/Makefile.am $(am__DIST_COMMON)
@@ -397,9 +395,9 @@ $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__confi
 	      exit 1;; \
 	  esac; \
 	done; \
-	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu --ignore-deps libstuff/Makefile'; \
+	echo ' cd $(top_srcdir) && $(AUTOMAKE) --foreign --ignore-deps libstuff/Makefile'; \
 	$(am__cd) $(top_srcdir) && \
-	  $(AUTOMAKE) --gnu --ignore-deps libstuff/Makefile
+	  $(AUTOMAKE) --foreign --ignore-deps libstuff/Makefile
 Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	@case '$?' in \
 	  *config.status*) \

--- a/cctools/man/Makefile.in
+++ b/cctools/man/Makefile.in
@@ -90,10 +90,8 @@ host_triplet = @host@
 target_triplet = @target@
 subdir = man
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
-	$(top_srcdir)/m4/llvm.m4 $(top_srcdir)/m4/ltoptions.m4 \
-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
-	$(top_srcdir)/m4/lt~obsolete.m4 $(top_srcdir)/configure.ac
+am__aclocal_m4_deps = $(top_srcdir)/m4/llvm.m4 \
+	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
 DIST_COMMON = $(srcdir)/Makefile.am $(am__DIST_COMMON)
@@ -329,9 +327,9 @@ $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__confi
 	      exit 1;; \
 	  esac; \
 	done; \
-	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu --ignore-deps man/Makefile'; \
+	echo ' cd $(top_srcdir) && $(AUTOMAKE) --foreign --ignore-deps man/Makefile'; \
 	$(am__cd) $(top_srcdir) && \
-	  $(AUTOMAKE) --gnu --ignore-deps man/Makefile
+	  $(AUTOMAKE) --foreign --ignore-deps man/Makefile
 Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	@case '$?' in \
 	  *config.status*) \

--- a/cctools/misc/Makefile.in
+++ b/cctools/misc/Makefile.in
@@ -99,10 +99,8 @@ bin_PROGRAMS = checksyms$(EXEEXT) lipo$(EXEEXT) size$(EXEEXT) \
 	check_dylib$(EXEEXT) cmpdylib$(EXEEXT) inout$(EXEEXT)
 subdir = misc
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
-	$(top_srcdir)/m4/llvm.m4 $(top_srcdir)/m4/ltoptions.m4 \
-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
-	$(top_srcdir)/m4/lt~obsolete.m4 $(top_srcdir)/configure.ac
+am__aclocal_m4_deps = $(top_srcdir)/m4/llvm.m4 \
+	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
 DIST_COMMON = $(srcdir)/Makefile.am $(am__DIST_COMMON)
@@ -503,9 +501,9 @@ $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__confi
 	      exit 1;; \
 	  esac; \
 	done; \
-	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu --ignore-deps misc/Makefile'; \
+	echo ' cd $(top_srcdir) && $(AUTOMAKE) --foreign --ignore-deps misc/Makefile'; \
 	$(am__cd) $(top_srcdir) && \
-	  $(AUTOMAKE) --gnu --ignore-deps misc/Makefile
+	  $(AUTOMAKE) --foreign --ignore-deps misc/Makefile
 Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	@case '$?' in \
 	  *config.status*) \

--- a/cctools/otool/Makefile.in
+++ b/cctools/otool/Makefile.in
@@ -92,10 +92,8 @@ target_triplet = @target@
 bin_PROGRAMS = otool$(EXEEXT)
 subdir = otool
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
-am__aclocal_m4_deps = $(top_srcdir)/m4/libtool.m4 \
-	$(top_srcdir)/m4/llvm.m4 $(top_srcdir)/m4/ltoptions.m4 \
-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
-	$(top_srcdir)/m4/lt~obsolete.m4 $(top_srcdir)/configure.ac
+am__aclocal_m4_deps = $(top_srcdir)/m4/llvm.m4 \
+	$(top_srcdir)/configure.ac
 am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 	$(ACLOCAL_M4)
 DIST_COMMON = $(srcdir)/Makefile.am $(am__DIST_COMMON)
@@ -386,9 +384,9 @@ $(srcdir)/Makefile.in: @MAINTAINER_MODE_TRUE@ $(srcdir)/Makefile.am  $(am__confi
 	      exit 1;; \
 	  esac; \
 	done; \
-	echo ' cd $(top_srcdir) && $(AUTOMAKE) --gnu --ignore-deps otool/Makefile'; \
+	echo ' cd $(top_srcdir) && $(AUTOMAKE) --foreign --ignore-deps otool/Makefile'; \
 	$(am__cd) $(top_srcdir) && \
-	  $(AUTOMAKE) --gnu --ignore-deps otool/Makefile
+	  $(AUTOMAKE) --foreign --ignore-deps otool/Makefile
 Makefile: $(srcdir)/Makefile.in $(top_builddir)/config.status
 	@case '$?' in \
 	  *config.status*) \


### PR DESCRIPTION
I fixed some the compile errors when compiling on linux related to differences between BSD and linux.

I compiled with libtapi 2.0.0 patched by me [here](https://github.com/martin31821/apple-libtapi)

## Issues

- Had to disable ObjectDump due to strange linking errors.
- Don't know whether the ld binaries are working correctly, I could link a binary and it seems to be recognized as a valid machO binary